### PR TITLE
feat: pause animation on mouse leave

### DIFF
--- a/src/components/FingerPoint.js
+++ b/src/components/FingerPoint.js
@@ -11,7 +11,7 @@ const FingerPoint = () => (
     xmlns="http://www.w3.org/2000/svg"
   >
     <title id="finger-point">Finger pointing icon.</title>
-    <g clip-path="url(#clip0)">
+    <g clipPath="url(#clip0)">
       <path
         d="M31.8043 19.3637L37.5308 17.8061L38.0002 14.463L20.5278 18.9096L19.9747 17.5645L26.4211 14.4627L24.4352 10.756L17.4222 13.7258L13.5978 16.9852L13.4827 19.3638L15.9607 24.5431L22.9485 21.1135L31.8043 19.3637Z"
         fill="#F7CC42"

--- a/src/components/Header/ThemeToggler.js
+++ b/src/components/Header/ThemeToggler.js
@@ -6,19 +6,40 @@ import { ThemeIcon } from './ThemeIcon'
 import colors from '../../lib/colors'
 
 const spin = keyframes`
-  from {
+  0% {
     transform: rotate (0deg);
   }
 
-  to {
+  25% {
+    transform: rotate (90deg);
+  }
+
+  50% {
+    transform: rotate (180deg);
+  }
+
+  75% {
+    transform: rotate (270deg);
+  }
+
+  100% {
     transform: rotate(360deg);
   }
 `
 
 const ThemeToggler = ({ toggleTheme, themeName }) => {
+  const [animationPlayState, setAnimationPlayState] = React.useState('paused')
   const theme = useTheme()
 
   const isDarkTheme = themeName === 'dark'
+
+  function resumeAnimation() {
+    setAnimationPlayState('running')
+  }
+
+  function pauseAnimation() {
+    setAnimationPlayState('paused')
+  }
 
   return (
     <Button
@@ -33,10 +54,12 @@ const ThemeToggler = ({ toggleTheme, themeName }) => {
         margin: 0,
         color: theme.colors.white,
         background: colors.transparent,
+        animation: `${spin} 3s linear infinite`,
+        // animationTimingFunction: 'ease-in-out',
+        animationPlayState,
         '@media (hover: hover)': {
           ':hover': {
             background: colors.transparent,
-            animation: `${spin} 3s linear infinite`,
           },
           ':active': {
             background: colors.transparent,
@@ -45,6 +68,8 @@ const ThemeToggler = ({ toggleTheme, themeName }) => {
       }}
       aria-label={`Switch to ${isDarkTheme ? 'light' : 'dark'} mode`}
       onClick={() => toggleTheme(isDarkTheme ? 'default' : 'dark')}
+      onMouseEnter={() => resumeAnimation()}
+      onMouseLeave={() => pauseAnimation()}
     >
       <ThemeIcon
         title={`Switch to ${isDarkTheme ? 'light' : 'dark'} mode`}


### PR DESCRIPTION
This PR pauses the theme toggler animation on hover off. Not perfect but an improvement. 

## Changes

- pause animation on hover off

## Screenshots

![2020-05-25 17 04 37](https://user-images.githubusercontent.com/3806031/82848794-f2e55980-9ea9-11ea-8ce6-e3892fe210c6.gif)


## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

Fixes #15 
