### PR TITLE
feat: create redirects and add egghead

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,0 +1,1 @@
+/eggheadio      https://egghead.io/instructors/joe-previte


### PR DESCRIPTION
This PR...

## Changes

Creates a URL-shortener that points `joeprevite.com/eggheadio` to  `https://egghead.io/instructors/joe-previte`. 

Using Netlify URL redirects. 

## Checklist

- [x] tested locally
- [x] added new dependencies

